### PR TITLE
Added -stdlib=libc++ so gcc/clang will find C++ 11 features on the Mac

### DIFF
--- a/anagram/CMakeLists.txt
+++ b/anagram/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Boost 1.55 REQUIRED COMPONENTS unit_test_framework date_time regex)
 
 # gcc/clang won't enable C++11 features without this flag
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(GNU|Clang)")
-    set(CMAKE_CXX_FLAGS "-std=c++11")
+    set(CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
 endif()
 
 # Configure to run all the tests?


### PR DESCRIPTION
Added c++ compiler flag so that the compiler will find include files on Mac for C++ 11.  Don't know if this will work on Linux, I'm trying to set up an environment to test that in.  Closes #1786