### PR TITLE
queen-attack is missing tests (and example implementation) for the other diagonal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 tmp
 bin/configlet
 bin/configlet.exe
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake

--- a/queen-attack/example.cpp
+++ b/queen-attack/example.cpp
@@ -41,7 +41,8 @@ bool chess_board::can_attack() const
 {
     return (white_.first == black_.first)
         || (white_.second == black_.second)
-        || ((white_.first - black_.first) == (white_.second - black_.second));
+        || ((white_.first - black_.first) == (white_.second - black_.second))
+        || ((white_.first - black_.first) == (black_.second - white_.second));
 }
 
 }

--- a/queen-attack/queen_attack_test.cpp
+++ b/queen-attack/queen_attack_test.cpp
@@ -102,4 +102,18 @@ BOOST_AUTO_TEST_CASE(queens_can_attack_yet_another_diagonally)
 
     BOOST_REQUIRE(board.can_attack());
 }
+
+BOOST_AUTO_TEST_CASE(queens_can_attack_on_the_nw_so_diagonal)
+{
+    const queen_attack::chess_board board{std::make_pair(1, 6), std::make_pair(6, 1)};
+
+    BOOST_REQUIRE(board.can_attack());
+}
+
+BOOST_AUTO_TEST_CASE(queens_cannot_attack_if_not_on_same_row_column_or_diagonal)
+{
+    const queen_attack::chess_board board{std::make_pair(1, 1), std::make_pair(3, 7)};
+
+    BOOST_REQUIRE(!board.can_attack());
+}
 #endif


### PR DESCRIPTION
The unit tests and the example implementation test the north-west / south-east diagonal, but are missing the north-east / south-west diagonal.
Also there is no test case where the queens are _not_ attacking each other.