### PR TITLE
Add testcase with invalid char at the end

### DIFF
--- a/binary/binary_test.cpp
+++ b/binary/binary_test.cpp
@@ -42,4 +42,9 @@ BOOST_AUTO_TEST_CASE(carrot_is_decimal_0)
 {
     BOOST_REQUIRE_EQUAL(0, binary::convert("convert"));
 }
+
+BOOST_AUTO_TEST_CASE(x1100101b_is_decimal_0)
+{
+    BOOST_REQUIRE_EQUAL(0, binary::convert("1100101b"));
+}
 #endif


### PR DESCRIPTION
Made this to make more clear how input shall be handled that looks valid right away from start but turns out to be invalid somewhere in the middle or the end.

The behaviour I test against should match the current behaviour of the reference-implementation. But perhaps we should require to `throw` something instead?