### PR TITLE
Normalize YAML in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
+---
 language: cpp
-
 compiler:
-  - gcc
-  - clang
-
+- gcc
+- clang
 before_install:
-  - sudo add-apt-repository -y ppa:kalakris/cmake
-  - sudo add-apt-repository -y ppa:boost-latest/ppa
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get -qq -d update
-
+- sudo add-apt-repository -y ppa:kalakris/cmake
+- sudo add-apt-repository -y ppa:boost-latest/ppa
+- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+- sudo apt-get -qq -d update
 install:
-  - sudo apt-get -qq install libboost1.55-all-dev cmake g++-4.8
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-
+- sudo apt-get -qq install libboost1.55-all-dev cmake g++-4.8
+- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 script:
-  - bin/fetch-configlet
-  - bin/configlet .
-  - cmake -G "Unix Makefiles"
-  - make
+- bin/fetch-configlet
+- bin/configlet .
+- cmake -G "Unix Makefiles"
+- make


### PR DESCRIPTION
The YAML was not quite valid. Travis can read it
and wasn't complaining, but this ensures that the YAML
is clean.