### PR TITLE
Switch to container-based Travis CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
 - bin/configlet .
 - cmake -G "Unix Makefiles"
 - make
+sudo: false


### PR DESCRIPTION
This gets us off the legacy build system, which means
that the builds will start more quickly and also likely
run more quickly (and with more consistent build times).

See https://docs.travis-ci.com/user/migrating-from-legacy.