### PR TITLE
Use BOOST_TEST for map equality in word_count

### DIFF
--- a/word-count/word_count_test.cpp
+++ b/word-count/word_count_test.cpp
@@ -19,7 +19,7 @@ operator<<(wrap_stringstream& wrapped, std::pair<const K, V> const& item)
 }
 
 #define REQUIRE_EQUAL_CONTAINERS(left_, right_) \
-    BOOST_REQUIRE_EQUAL_COLLECTIONS(left_.begin(), left_.end(), right_.begin(), right_.end())
+    BOOST_TEST(left_ == right_);
 
 BOOST_AUTO_TEST_CASE(counts_one_word)
 {


### PR DESCRIPTION
Fix exercism/exercism.io#2616

BOOST_REQUIRE_EQUAL_COLLECTIONS isn't valid in the current version of boost (1.59.0). Using BOOST_TEST in the word_count test suite fixes a compilation error as described in exercism/exercism.io#2616