### PR TITLE
Hopefully fix formatting of bulleted list.

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -64,6 +64,7 @@ latest version of the Microsoft Visual C++ compiler.
 CMake is an open source cross-platform build system that generates build
 scripts for your native build system (`make`, Visual Studio, Xcode, etc.).
 Exercism's C++ track uses CMake to give you a ready-made build that:
+
 * compiles the tests
 * compiles your solution
 * links the test executable


### PR DESCRIPTION
A bulleted list in the [Installing C++](http://exercism.io/languages/cpp) page looks fine when rendered in GitHub as markdown, but I guess Redcarpet or something might be parsing/rendering slightly differently, because it shows up like this on the website:

> ![2016-02-14_7-15-38](https://cloud.githubusercontent.com/assets/124687/13033597/ea524de4-d2ea-11e5-8b3f-79aeabf2cd8f.png)

I am guessing that my fix will fix things but I didn't actually test it out.