### PR TITLE
fix pair printing in word-count to work in boost v 1.59 and above

### DIFF
--- a/etl/etl_test.cpp
+++ b/etl/etl_test.cpp
@@ -2,6 +2,7 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
+#if BOOST_VERSION < 105900
 namespace boost
 {
 
@@ -14,6 +15,18 @@ operator<<(wrap_stringstream& wrapped, std::pair<const K, V> const& item)
 }
 
 }
+#else
+namespace boost { namespace test_tools { namespace tt_detail {
+
+template <typename K, typename V>
+inline std::ostream&
+operator<<(std::ostream& os, std::pair<const K, V> const& item)
+{
+    return os << '<' << item.first << ',' << item.second << '>';
+}
+
+}}}
+#endif
 
 #define REQUIRE_EQUAL_CONTAINERS(left_, right_) \
     BOOST_REQUIRE_EQUAL_COLLECTIONS(left_.begin(), left_.end(), right_.begin(), right_.end())

--- a/grade-school/grade_school_test.cpp
+++ b/grade-school/grade_school_test.cpp
@@ -2,6 +2,7 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
+#if BOOST_VERSION < 105900
 namespace boost
 {
 
@@ -28,6 +29,29 @@ operator<<(wrap_stringstream& wrapped, std::pair<const K, V> const& item)
 }
 
 }
+#else
+namespace boost { namespace test_tools { namespace tt_detail {
+
+template <typename T> inline std::ostream&
+operator<<(std::ostream& os, std::vector<T> const& item)
+{
+    os << '[';
+    bool first = true;
+    for (auto const& element : item) {
+        os << (!first ? "," : "") << element;
+        first = false;
+    }
+    return os << ']';
+}
+
+template <typename K, typename V> inline std::ostream&
+operator<<(std::ostream& os, std::pair<const K, V> const& item)
+{
+    return os << '<' << item.first << ',' << item.second << '>';
+}
+
+}}}
+#endif
 
 #define REQUIRE_EQUAL_CONTAINERS(left_, right_) \
     BOOST_REQUIRE_EQUAL_COLLECTIONS(left_.begin(), left_.end(), right_.begin(), right_.end())

--- a/nucleotide-count/nucleotide_count_test.cpp
+++ b/nucleotide-count/nucleotide_count_test.cpp
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 #include <stdexcept>
 
+#if BOOST_VERSION < 105900
 namespace boost
 {
 
@@ -15,6 +16,18 @@ operator<<(wrap_stringstream& wrapped, std::pair<const K, V> const& item)
 }
 
 }
+#else
+namespace boost { namespace test_tools { namespace tt_detail {
+
+template <typename K, typename V>
+inline std::ostream&
+operator<<(std::ostream& os, std::pair<const K, V> const& item)
+{
+    return os << '<' << item.first << ',' << item.second << '>';
+}
+
+}}}
+#endif
 
 BOOST_AUTO_TEST_CASE(has_no_nucleotides)
 {

--- a/queen-attack/queen_attack_test.cpp
+++ b/queen-attack/queen_attack_test.cpp
@@ -2,6 +2,7 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
+#if BOOST_VERSION < 105900
 namespace boost
 {
 namespace test_tools
@@ -19,6 +20,18 @@ struct print_log_value<std::pair<int, int>>
 
 }
 }
+#else
+namespace boost { namespace test_tools { namespace tt_detail {
+
+template <typename K, typename V>
+inline std::ostream&
+operator<<(std::ostream& os, std::pair<K, V> const& item)
+{
+    return os << '<' << item.first << ',' << item.second << '>';
+}
+
+}}}
+#endif
 
 BOOST_AUTO_TEST_CASE(queens_in_default_positions)
 {

--- a/series/series_test.cpp
+++ b/series/series_test.cpp
@@ -3,6 +3,7 @@
 #include <boost/test/unit_test.hpp>
 #include <stdexcept>
 
+#if BOOST_VERSION < 105900
 namespace boost
 {
 
@@ -21,6 +22,24 @@ operator<<(wrap_stringstream& wrapped, std::vector<T> const& item)
 }
 
 }
+#else
+namespace boost { namespace test_tools { namespace tt_detail {
+
+template <typename T>
+inline std::ostream&
+operator<<(std::ostream& os, std::vector<T> const& item)
+{
+    return os << '[';
+    bool first = true;
+    for (auto const& element : item) {
+        os << (!first ? "," : "") << element;
+        first = false;
+    }
+    return os << ']';
+}
+
+}}}
+#endif
 
 using namespace std;
 

--- a/word-count/word_count_test.cpp
+++ b/word-count/word_count_test.cpp
@@ -5,6 +5,7 @@
 
 using namespace std;
 
+#if BOOST_VERSION < 105900
 namespace boost
 {
 
@@ -17,6 +18,20 @@ operator<<(wrap_stringstream& wrapped, std::pair<const K, V> const& item)
 }
 
 }
+
+#else
+
+namespace boost { namespace test_tools { namespace tt_detail {
+template<typename K, typename V>
+struct print_log_value<std::pair<const K, V>>
+{
+    void operator()(std::ostream& os, std::pair<const K, V> const& item)
+    {
+        os << '<' << item.first << ',' << item.second << '>';
+    }
+};
+}}}
+#endif
 
 #define REQUIRE_EQUAL_CONTAINERS(left_, right_) \
     BOOST_REQUIRE_EQUAL_COLLECTIONS(left_.begin(), left_.end(), right_.begin(), right_.end())


### PR DESCRIPTION
I think a Travis job that that would run the tests against latest version of boost would be a good idea.