### PR TITLE
sum-of-multiples: Removing implicit list of multiples

### DIFF
--- a/sum-of-multiples/example.cpp
+++ b/sum-of-multiples/example.cpp
@@ -3,11 +3,6 @@
 namespace sum_of_multiples
 {
 
-int to(int num)
-{
-    return to({3, 5}, num);
-}
-
 int to(std::initializer_list<int> const& multiples, int num)
 {
     int sum = 0;

--- a/sum-of-multiples/example.h
+++ b/sum-of-multiples/example.h
@@ -6,8 +6,6 @@
 namespace sum_of_multiples
 {
 
-int to(int num);
-
 int to(std::initializer_list<int> const& multiples, int num);
 
 }

--- a/sum-of-multiples/sum_of_multiples_test.cpp
+++ b/sum-of-multiples/sum_of_multiples_test.cpp
@@ -4,28 +4,28 @@
 
 BOOST_AUTO_TEST_CASE(sum_to_1_yields_0)
 {
-    BOOST_REQUIRE_EQUAL(0, sum_of_multiples::to(0));
+    BOOST_REQUIRE_EQUAL(0, sum_of_multiples::to({3, 5}, 0));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 BOOST_AUTO_TEST_CASE(sum_to_4_yields_3)
 {
-    BOOST_REQUIRE_EQUAL(3, sum_of_multiples::to(4));
+    BOOST_REQUIRE_EQUAL(3, sum_of_multiples::to({3, 5}, 4));
 }
 
 BOOST_AUTO_TEST_CASE(sum_to_10_yields_23)
 {
-    BOOST_REQUIRE_EQUAL(23, sum_of_multiples::to(10));
+    BOOST_REQUIRE_EQUAL(23, sum_of_multiples::to({3, 5}, 10));
 }
 
 BOOST_AUTO_TEST_CASE(sum_to_100)
 {
-    BOOST_REQUIRE_EQUAL(2318, sum_of_multiples::to(100));
+    BOOST_REQUIRE_EQUAL(2318, sum_of_multiples::to({3, 5}, 100));
 }
 
 BOOST_AUTO_TEST_CASE(sum_to_1000)
 {
-    BOOST_REQUIRE_EQUAL(233168, sum_of_multiples::to(1000));
+    BOOST_REQUIRE_EQUAL(233168, sum_of_multiples::to({3, 5}, 1000));
 }
 
 BOOST_AUTO_TEST_CASE(sum_of_7_13_17_to_20_yields_51)
@@ -33,8 +33,33 @@ BOOST_AUTO_TEST_CASE(sum_of_7_13_17_to_20_yields_51)
     BOOST_REQUIRE_EQUAL(51, sum_of_multiples::to({7, 13, 17}, 20));
 }
 
+BOOST_AUTO_TEST_CASE(sum_of_4_6_to_15)
+{
+    BOOST_REQUIRE_EQUAL(30, sum_of_multiples::to({4, 6}, 15));
+}
+
+BOOST_AUTO_TEST_CASE(sum_of_5_6_8_to_150)
+{
+    BOOST_REQUIRE_EQUAL(4419, sum_of_multiples::to({5, 6, 8}, 150));
+}
+
+BOOST_AUTO_TEST_CASE(sum_of_5_25_to_51)
+{
+    BOOST_REQUIRE_EQUAL(275, sum_of_multiples::to({5, 25}, 51));
+}
+
 BOOST_AUTO_TEST_CASE(sum_of_43_47_to_10000)
 {
     BOOST_REQUIRE_EQUAL(2203160, sum_of_multiples::to({43, 47}, 10000));
+}
+
+BOOST_AUTO_TEST_CASE(sum_of_1_to_100)
+{
+    BOOST_REQUIRE_EQUAL(4950, sum_of_multiples::to({1}, 100));
+}
+
+BOOST_AUTO_TEST_CASE(sum_of_empty_list)
+{
+    BOOST_REQUIRE_EQUAL(0, sum_of_multiples::to({}, 10000));
 }
 #endif


### PR DESCRIPTION
Updates the tests and example solution to require an explicit
declaration of multiples, matching the test cases from x-common/sum-of-multiples.json

To fix Issue #71 