### PR TITLE
robot-name: Require uppercase letters

### DIFF
--- a/robot-name/example.cpp
+++ b/robot-name/example.cpp
@@ -14,7 +14,7 @@ namespace
 string next_prefix(string const &prefix)
 {
     string next{prefix};
-    const string letters{"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"};
+    const string letters{"ABCDEFGHIJKLMNOPQRSTUVWXYZ"};
     if (prefix[1] == letters.back()) {
         if (prefix[0] == letters.back()) {
             throw range_error("prefix combinations exhausted");

--- a/robot-name/robot_name_test.cpp
+++ b/robot-name/robot_name_test.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 namespace
 {
-const boost::regex name_pattern{R"name(^[[:alpha:]]{2}\d{3}$)name"};
+const boost::regex name_pattern{R"name(^[[:upper:]]{2}\d{3}$)name"};
 }
 
 BOOST_AUTO_TEST_CASE(has_a_name)


### PR DESCRIPTION
Update robot-name to allow only uppercase letters. This keeps the xcpp
track updated with the current instructions. See exercism/x-common#283