### PR TITLE
clock: Adding full test suite.

### DIFF
--- a/exercises/clock/clock_test.cpp
+++ b/exercises/clock/clock_test.cpp
@@ -4,81 +4,188 @@
 
 using namespace std;
 
-BOOST_AUTO_TEST_CASE(prints_the_hour)
+struct timeTest {
+    int hour;
+    int minute;
+    string expected;
+};
+
+vector<timeTest> timeCases = {
+    {8, 0, "08:00"},        // on the hour
+    {11, 9, "11:09"},       // past the hour
+    {24, 0, "00:00"},       // midnight is zero hours
+    {25, 0, "01:00"},       // hour rolls over
+    {100, 0, "04:00"},      // hour rolls over continuously
+    {1, 60, "02:00"},       // sixty minutes is next hour
+    {0, 160, "02:40"},      // minutes roll over
+    {0, 1723, "04:43"},     // minutes roll over continuously
+    {25, 160, "03:40"},     // hour and minutes roll over
+    {201, 3001, "11:01"},   // hour and minutes roll over continuously
+    {72, 8640, "00:00"},    // hour and minutes roll over to exactly midnight
+    {-1, 15, "23:15"},      // negative hour
+    {-25, 0, "23:00"},      // negative hour rolls over
+    {-91, 0, "05:00"},      // negative hour rolls over continuously
+    {1, -40, "00:20"},      // negative minutes
+    {1, -160, "22:20"},     // negative minutes roll over
+    {1, -4820, "16:40"},    // negative minutes roll over continuously
+    {-25, -160, "20:20"},   // negative hour and minutes both roll over
+    {-121, -5810, "22:10"}  // negative hour and minutes both roll over continuously
+};
+
+struct addTest {
+    int hour;
+    int minute;
+    int add;
+    string expected;
+};
+
+vector<addTest> addCases = {
+    {10, 0, 3, "10:03"},     // add minutes
+    {6, 41, 0, "06:41"},     // add no minutes
+    {0, 45, 40, "01:25"},    // add to next hour
+    {10, 0, 61, "11:01"},    // add more than one hour
+    {0, 45, 160, "03:25"},   // add more than two hours with carry
+    {23, 59, 2, "00:01"},    // add across midnight
+    {5, 32, 1500, "06:32"},  // add more than one day (1500 min = 25 hrs)
+    {1, 1, 3500, "11:21"},   // add more than two days
+    {10, 3, -3, "10:00"},    // subtract minutes
+    {10, 3, -30, "09:33"},   // subtract to previous hour
+    {10, 3, -70, "08:53"},   // subtract more than an hour
+    {0, 3, -4, "23:59"},     // subtract across midnight
+    {0, 0, -160, "21:20"},   // subtract more than two hours
+    {6, 15, -160, "03:35"},  // subtract more than two hours with borrow
+    {5, 32, -1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
+    {2, 20, -3000, "00:20"}  // subtract more than two days
+};
+
+// Construct two separate clocks, set times, test if they are equal.
+struct hm {
+    int hour;
+    int minute;
+};
+
+struct equalTest {
+    hm c1;
+    hm c2;
+    bool expected;
+};
+
+vector<equalTest> equalCases = {
+    // clocks with same time
+    {
+        hm{15, 37},
+        hm{15, 37},
+        true,
+    },
+    // clocks a minute apart
+    {
+        hm{15, 36},
+        hm{15, 37},
+        false,
+    },
+    // clocks an hour apart
+    {
+        hm{14, 37},
+        hm{15, 37},
+        false,
+    },
+    // clocks with hour overflow
+    {
+        hm{10, 37},
+        hm{34, 37},
+        true,
+    },
+    // clocks with hour overflow by several days
+    {
+        hm{3, 11},
+        hm{99, 11},
+        true,
+    },
+    // clocks with negative hour
+    {
+        hm{22, 40},
+        hm{-2, 40},
+        true,
+    },
+    // clocks with negative hour that wraps
+    {
+        hm{17, 3},
+        hm{-31, 3},
+        true,
+    },
+    // clocks with negative hour that wraps multiple times
+    {
+        hm{13, 49},
+        hm{-83, 49},
+        true,
+    },
+    // clocks with minute overflow
+    {
+        hm{0, 1},
+        hm{0, 1441},
+        true,
+    },
+    // clocks with minute overflow by several days
+    {
+        hm{2, 2},
+        hm{2, 4322},
+        true,
+    },
+    // clocks with negative minute
+    {
+        hm{2, 40},
+        hm{3, -20},
+        true,
+    },
+    // clocks with negative minute that wraps
+    {
+        hm{4, 10},
+        hm{5, -1490},
+        true,
+    },
+    // clocks with negative minute that wraps multiple times
+    {
+        hm{6, 15},
+        hm{6, -4305},
+        true,
+    },
+    // clocks with negative hours and minutes
+    {
+        hm{7, 32},
+        hm{-12, -268},
+        true,
+    },
+    // clocks with negative hours and minutes that wrap
+    {
+        hm{18, 7},
+        hm{-54, -11513},
+        true,
+    },
+};
+
+BOOST_AUTO_TEST_CASE(time_tests)
 {
-    BOOST_REQUIRE_EQUAL("08:00", string(date_independent::clock::at(8)));
-    BOOST_REQUIRE_EQUAL("09:00", string(date_independent::clock::at(9)));
+    for (timeTest t : timeCases)
+        BOOST_REQUIRE_EQUAL(t.expected, string(date_independent::clock::at(t.hour, t.minute)));
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
-BOOST_AUTO_TEST_CASE(prints_past_the_hour)
+BOOST_AUTO_TEST_CASE(add_tests)
 {
-    BOOST_REQUIRE_EQUAL("11:09", string(date_independent::clock::at(11, 9)));
-    BOOST_REQUIRE_EQUAL("11:19", string(date_independent::clock::at(11, 19)));
+    for (addTest a : addCases)
+        BOOST_REQUIRE_EQUAL(a.expected, string(date_independent::clock::at(a.hour, a.minute).plus(a.add)));
 }
 
-BOOST_AUTO_TEST_CASE(can_add_minutes)
+BOOST_AUTO_TEST_CASE(equal_tests)
 {
-    const auto clock = date_independent::clock::at(10).plus(3);
+    for (equalTest e : equalCases) {
+        const auto clock1 = date_independent::clock::at(e.c1.hour, e.c1.minute);
+        const auto clock2 = date_independent::clock::at(e.c2.hour, e.c2.minute);
 
-    BOOST_REQUIRE_EQUAL("10:03", string(clock));
-}
-
-BOOST_AUTO_TEST_CASE(can_add_over_an_hour)
-{
-    const auto clock = date_independent::clock::at(10).plus(61);
-
-    BOOST_REQUIRE_EQUAL("11:01", string(clock));
-}
-
-BOOST_AUTO_TEST_CASE(wraps_around_midnight)
-{
-    const auto clock = date_independent::clock::at(23, 59).plus(2);
-
-    BOOST_REQUIRE_EQUAL("00:01", string(clock));
-}
-
-BOOST_AUTO_TEST_CASE(can_subtract_minutes)
-{
-    const auto clock = date_independent::clock::at(10, 3).minus(3);
-
-    BOOST_REQUIRE_EQUAL("10:00", string(clock));
-}
-
-BOOST_AUTO_TEST_CASE(can_subtract_to_previous_hour)
-{
-    const auto clock = date_independent::clock::at(10, 3).minus(30);
-
-    BOOST_REQUIRE_EQUAL("09:33", string(clock));
-}
-
-BOOST_AUTO_TEST_CASE(can_subtract_over_an_hour)
-{
-    const auto clock = date_independent::clock::at(10, 3).minus(70);
-
-    BOOST_REQUIRE_EQUAL("08:53", string(clock));
-}
-
-BOOST_AUTO_TEST_CASE(can_know_if_its_equal_to_another_clock)
-{
-    const auto clock1 = date_independent::clock::at(10, 3);
-    const auto clock2 = date_independent::clock::at(10, 3);
-
-    BOOST_REQUIRE(clock1 == clock2);
-}
-
-BOOST_AUTO_TEST_CASE(can_know_if_its_not_equal_to_another_clock)
-{
-    const auto clock1 = date_independent::clock::at(10, 3);
-    const auto clock2 = date_independent::clock::at(10, 4);
-
-    BOOST_REQUIRE(clock1 != clock2);
-}
-
-BOOST_AUTO_TEST_CASE(wraps_around_midnight_backwards)
-{
-    const auto clock = date_independent::clock::at(0, 3).minus(4);
-
-    BOOST_REQUIRE_EQUAL("23:59", string(clock));
+        if (e.expected)
+            BOOST_REQUIRE_MESSAGE(clock1 == clock2, string(clock1) << " != " << string(clock2));
+        else
+            BOOST_REQUIRE_MESSAGE(clock1 != clock2, string(clock1) << " == " << string(clock2));
+    }
 }
 #endif

--- a/exercises/clock/clock_test.cpp
+++ b/exercises/clock/clock_test.cpp
@@ -8,28 +8,29 @@ struct timeTest {
     int hour;
     int minute;
     string expected;
+    string msg;
 };
 
 vector<timeTest> timeCases = {
-    {8, 0, "08:00"},        // on the hour
-    {11, 9, "11:09"},       // past the hour
-    {24, 0, "00:00"},       // midnight is zero hours
-    {25, 0, "01:00"},       // hour rolls over
-    {100, 0, "04:00"},      // hour rolls over continuously
-    {1, 60, "02:00"},       // sixty minutes is next hour
-    {0, 160, "02:40"},      // minutes roll over
-    {0, 1723, "04:43"},     // minutes roll over continuously
-    {25, 160, "03:40"},     // hour and minutes roll over
-    {201, 3001, "11:01"},   // hour and minutes roll over continuously
-    {72, 8640, "00:00"},    // hour and minutes roll over to exactly midnight
-    {-1, 15, "23:15"},      // negative hour
-    {-25, 0, "23:00"},      // negative hour rolls over
-    {-91, 0, "05:00"},      // negative hour rolls over continuously
-    {1, -40, "00:20"},      // negative minutes
-    {1, -160, "22:20"},     // negative minutes roll over
-    {1, -4820, "16:40"},    // negative minutes roll over continuously
-    {-25, -160, "20:20"},   // negative hour and minutes both roll over
-    {-121, -5810, "22:10"}  // negative hour and minutes both roll over continuously
+    {8, 0, "08:00",        "on the hour"},
+    {11, 9, "11:09",       "past the hour"},
+    {24, 0, "00:00",       "midnight is zero hours"},
+    {25, 0, "01:00",       "hour rolls over"},
+    {100, 0, "04:00",      "hour rolls over continuously"},
+    {1, 60, "02:00",       "sixty minutes is next hour"},
+    {0, 160, "02:40",      "minutes roll over"},
+    {0, 1723, "04:43",     "minutes roll over continuously"},
+    {25, 160, "03:40",     "hour and minutes roll over"},
+    {201, 3001, "11:01",   "hour and minutes roll over continuously"},
+    {72, 8640, "00:00",    "hour and minutes roll over to exactly midnight"},
+    {-1, 15, "23:15",      "negative hour"},
+    {-25, 0, "23:00",      "negative hour rolls over"},
+    {-91, 0, "05:00",      "negative hour rolls over continuously"},
+    {1, -40, "00:20",      "negative minutes"},
+    {1, -160, "22:20",     "negative minutes roll over"},
+    {1, -4820, "16:40",    "negative minutes roll over continuously"},
+    {-25, -160, "20:20",   "negative hour and minutes both roll over"},
+    {-121, -5810, "22:10", "negative hour and minutes both roll over continuously"},
 };
 
 struct addTest {
@@ -37,25 +38,26 @@ struct addTest {
     int minute;
     int add;
     string expected;
+    string msg;
 };
 
 vector<addTest> addCases = {
-    {10, 0, 3, "10:03"},     // add minutes
-    {6, 41, 0, "06:41"},     // add no minutes
-    {0, 45, 40, "01:25"},    // add to next hour
-    {10, 0, 61, "11:01"},    // add more than one hour
-    {0, 45, 160, "03:25"},   // add more than two hours with carry
-    {23, 59, 2, "00:01"},    // add across midnight
-    {5, 32, 1500, "06:32"},  // add more than one day (1500 min = 25 hrs)
-    {1, 1, 3500, "11:21"},   // add more than two days
-    {10, 3, -3, "10:00"},    // subtract minutes
-    {10, 3, -30, "09:33"},   // subtract to previous hour
-    {10, 3, -70, "08:53"},   // subtract more than an hour
-    {0, 3, -4, "23:59"},     // subtract across midnight
-    {0, 0, -160, "21:20"},   // subtract more than two hours
-    {6, 15, -160, "03:35"},  // subtract more than two hours with borrow
-    {5, 32, -1500, "04:32"}, // subtract more than one day (1500 min = 25 hrs)
-    {2, 20, -3000, "00:20"}  // subtract more than two days
+    {10, 0, 3, "10:03",     "add minutes"},
+    {6, 41, 0, "06:41",     "add no minutes"},
+    {0, 45, 40, "01:25",    "add to next hour"},
+    {10, 0, 61, "11:01",    "add more than one hour"},
+    {0, 45, 160, "03:25",   "add more than two hours with carry"},
+    {23, 59, 2, "00:01",    "add across midnight"},
+    {5, 32, 1500, "06:32",  "add more than one day (1500 min = 25 hrs)"},
+    {1, 1, 3500, "11:21",   "add more than two days"},
+    {10, 3, -3, "10:00",    "subtract minutes"},
+    {10, 3, -30, "09:33",   "subtract to previous hour"},
+    {10, 3, -70, "08:53",   "subtract more than an hour"},
+    {0, 3, -4, "23:59",     "subtract across midnight"},
+    {0, 0, -160, "21:20",   "subtract more than two hours"},
+    {6, 15, -160, "03:35",  "subtract more than two hours with borrow"},
+    {5, 32, -1500, "04:32", "subtract more than one day (1500 min = 25 hrs)"},
+    {2, 20, -3000, "00:20", "subtract more than two days"},
 };
 
 // Construct two separate clocks, set times, test if they are equal.
@@ -65,115 +67,129 @@ struct hm {
 };
 
 struct equalTest {
+    string msg;
     hm c1;
     hm c2;
     bool expected;
 };
 
 vector<equalTest> equalCases = {
-    // clocks with same time
     {
+        "clocks with same time",
         hm{15, 37},
         hm{15, 37},
         true,
     },
-    // clocks a minute apart
     {
+        "clocks a minute apart",
         hm{15, 36},
         hm{15, 37},
         false,
     },
-    // clocks an hour apart
     {
+        "clocks an hour apart",
         hm{14, 37},
         hm{15, 37},
         false,
     },
-    // clocks with hour overflow
     {
+        "clocks with hour overflow",
         hm{10, 37},
         hm{34, 37},
         true,
     },
-    // clocks with hour overflow by several days
     {
+        "clocks with hour overflow by several days",
         hm{3, 11},
         hm{99, 11},
         true,
     },
-    // clocks with negative hour
     {
+        "clocks with negative hour",
         hm{22, 40},
         hm{-2, 40},
         true,
     },
-    // clocks with negative hour that wraps
     {
+        "clocks with negative hour that wraps",
         hm{17, 3},
         hm{-31, 3},
         true,
     },
-    // clocks with negative hour that wraps multiple times
     {
+        "clocks with negative hour that wraps multiple times",
         hm{13, 49},
         hm{-83, 49},
         true,
     },
-    // clocks with minute overflow
     {
+        "clocks with minute overflow",
         hm{0, 1},
         hm{0, 1441},
         true,
     },
-    // clocks with minute overflow by several days
     {
+        "clocks with minute overflow by several days",
         hm{2, 2},
         hm{2, 4322},
         true,
     },
-    // clocks with negative minute
     {
+        "clocks with negative minute",
         hm{2, 40},
         hm{3, -20},
         true,
     },
-    // clocks with negative minute that wraps
     {
+        "clocks with negative minute that wraps",
         hm{4, 10},
         hm{5, -1490},
         true,
     },
-    // clocks with negative minute that wraps multiple times
     {
+        "clocks with negative minute that wraps multiple times",
         hm{6, 15},
         hm{6, -4305},
         true,
     },
-    // clocks with negative hours and minutes
     {
+        "clocks with negative hours and minutes",
         hm{7, 32},
         hm{-12, -268},
         true,
     },
-    // clocks with negative hours and minutes that wrap
     {
+        "clocks with negative hours and minutes that wrap",
         hm{18, 7},
         hm{-54, -11513},
         true,
     },
 };
 
+string errorMsg(string expected, string actual, string test)
+{
+    stringstream ret;
+    ret << "[" << expected << " != " << actual << "] test case: " << test;
+    return ret.str();
+}
+
 BOOST_AUTO_TEST_CASE(time_tests)
 {
-    for (timeTest t : timeCases)
-        BOOST_REQUIRE_EQUAL(t.expected, string(date_independent::clock::at(t.hour, t.minute)));
+    for (timeTest t : timeCases) {
+        const auto actual = string(date_independent::clock::at(t.hour, t.minute));
+
+        BOOST_REQUIRE_MESSAGE(t.expected == actual, errorMsg(t.expected, actual, t.msg));
+    }
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 BOOST_AUTO_TEST_CASE(add_tests)
 {
-    for (addTest a : addCases)
-        BOOST_REQUIRE_EQUAL(a.expected, string(date_independent::clock::at(a.hour, a.minute).plus(a.add)));
+    for (addTest a : addCases) {
+        const auto actual = string(date_independent::clock::at(a.hour, a.minute).plus(a.add));
+
+        BOOST_REQUIRE_MESSAGE(a.expected == actual, errorMsg(a.expected, actual, a.msg));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(equal_tests)
@@ -183,9 +199,10 @@ BOOST_AUTO_TEST_CASE(equal_tests)
         const auto clock2 = date_independent::clock::at(e.c2.hour, e.c2.minute);
 
         if (e.expected)
-            BOOST_REQUIRE_MESSAGE(clock1 == clock2, string(clock1) << " != " << string(clock2));
+            BOOST_REQUIRE_MESSAGE(clock1 == clock2, errorMsg(string(clock1), string(clock2), e.msg));
         else
-            BOOST_REQUIRE_MESSAGE(clock1 != clock2, string(clock1) << " == " << string(clock2));
+            BOOST_REQUIRE_MESSAGE(clock1 != clock2,
+                    "[" << string(clock1) << " == " << string(clock2) << "] test case: " << e.msg);
     }
 }
 #endif

--- a/exercises/clock/example.cpp
+++ b/exercises/clock/example.cpp
@@ -18,24 +18,14 @@ namespace date_independent
 clock& clock::plus(int minutes)
 {
     minute_ += minutes;
-    if (minute_ > minutes_per_hour) {
-        hour_ += (minute_/minutes_per_hour);
-        hour_ %= hours_per_day;
-        minute_ %= minutes_per_hour;
-    }
+    clean();
     return *this;
 }
 
 clock& clock::minus(int minutes)
 {
     minute_ -= minutes;
-    while (minute_ < 0) {
-        --hour_;
-        minute_ += minutes_per_hour;
-    }
-    while (hour_ < 0) {
-        hour_ += hours_per_day;
-    }
+    clean();
     return *this;
 }
 
@@ -50,6 +40,21 @@ clock::clock(int hour, int minute)
     : hour_(hour),
     minute_(minute)
 {
+    clean();
+}
+
+void clock::clean()
+{
+    if (minute_ < 0) {
+        int tmp = 1 + (minute_ / -minutes_per_hour);
+        hour_ -= tmp;
+        minute_ += minutes_per_hour * tmp;
+    }
+    if (hour_ < 0)
+        hour_ += hours_per_day*(1 + (hour_ / -hours_per_day));
+    hour_ += minute_ / minutes_per_hour;
+    hour_ %= hours_per_day;
+    minute_ %= minutes_per_hour;
 }
 
 clock clock::at(int hour, int minute /*= 0*/)

--- a/exercises/clock/example.h
+++ b/exercises/clock/example.h
@@ -20,6 +20,7 @@ public:
 
 private:
     clock(int hour, int minute);
+    void clean();
     int hour_;
     int minute_;
 };


### PR DESCRIPTION
I updated the test suite for clock to match the new JSON, and fixed the example solution to work with it.

Because there are a _lot_ of test cases for clock, I copied how [the Go track handles the test cases](https://github.com/exercism/xgo/tree/master/exercises/clock), placing the test cases into a vector and iterating over them. This might make it a little difficult to tell which test case is failing, but I believe the Boost output messages handle it well enough.

This is different from all of the other test suites for the cpp track (I think), so it may require some review/rework.

Closes #78 
