### PR TITLE
anagram: clarify solution requirements

### DIFF
--- a/exercises/anagram/anagram_test.cpp
+++ b/exercises/anagram/anagram_test.cpp
@@ -6,7 +6,8 @@ using namespace std;
 
 BOOST_AUTO_TEST_CASE(no_matches)
 {
-    auto subject = anagram::anagram("diaper");
+    // 'anagram::anagram' defines a class
+    anagram::anagram subject = anagram::anagram("diaper");
     auto matches = subject.matches({"hello", "world", "zombies", "pants"});
     vector<string> expected;
 


### PR DESCRIPTION
This exercise is the first that requires the solver to define a class. This patch helps users who may be unfamiliar with the syntax determine what is required.

Learners (especially those new to programming or new to programming with classes) may have difficulty determining a class is required for the existing tests. This gives them something to google if they don't know what's going on.

Closes #98
