### PR TITLE
gigasecond: use times (not dates)

### DIFF
--- a/exercises/gigasecond/example.cpp
+++ b/exercises/gigasecond/example.cpp
@@ -3,13 +3,9 @@
 namespace gigasecond
 {
 
-boost::gregorian::date advance(const boost::gregorian::date& start)
+boost::posix_time::ptime advance(const boost::posix_time::ptime& start)
 {
-    const unsigned long long seconds_per_minute = 60;
-    const unsigned long long seconds_per_hour = 60*seconds_per_minute;
-    const unsigned long long seconds_per_day = 24*seconds_per_hour;
-    const unsigned long long one_giga_second = 1000000000;
-    return start + boost::gregorian::days(one_giga_second/seconds_per_day);
+    return start + boost::posix_time::seconds(1e9);
 }
 
 }

--- a/exercises/gigasecond/example.h
+++ b/exercises/gigasecond/example.h
@@ -1,12 +1,12 @@
 #if !defined(GIGASECOND_H)
 #define GIGASECOND_H
 
-#include <boost/date_time/gregorian/gregorian.hpp>
+#include "boost/date_time/posix_time/posix_time.hpp"
 
 namespace gigasecond
 {
 
-boost::gregorian::date advance(const boost::gregorian::date& start);
+boost::posix_time::ptime advance(const boost::posix_time::ptime& start);
 
 }
 

--- a/exercises/gigasecond/example.h
+++ b/exercises/gigasecond/example.h
@@ -1,7 +1,7 @@
 #if !defined(GIGASECOND_H)
 #define GIGASECOND_H
 
-#include "boost/date_time/posix_time/posix_time.hpp"
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 namespace gigasecond
 {

--- a/exercises/gigasecond/gigasecond_test.cpp
+++ b/exercises/gigasecond/gigasecond_test.cpp
@@ -2,7 +2,7 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
-// See <http://www.boost.org/doc/libs/1_61_0/doc/html/date_time/posix_time.html>
+// See <http://www.boost.org/doc/libs/1_59_0/doc/html/date_time/posix_time.html>
 // for documentation on boost::posix_time
 
 using namespace boost::posix_time;

--- a/exercises/gigasecond/gigasecond_test.cpp
+++ b/exercises/gigasecond/gigasecond_test.cpp
@@ -2,31 +2,49 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 
-// See <http://www.boost.org/doc/libs/1_59_0/doc/html/date_time.html>
-// for documentation on boost::gregorian::date
+// See <http://www.boost.org/doc/libs/1_61_0/doc/html/date_time/posix_time.html>
+// for documentation on boost::posix_time
+
+using namespace boost::posix_time;
 
 BOOST_AUTO_TEST_CASE(test_1)
 {
-    const auto actual = gigasecond::advance(boost::gregorian::date(2011, 4, 26));
+    const auto actual = gigasecond::advance(time_from_string("2011-04-25 00:00:00"));
 
-    const boost::gregorian::date expected(2043, 1, 2);
+    const ptime expected(time_from_string("2043-01-01 01:46:40"));
     BOOST_REQUIRE_EQUAL(expected, actual);
 }
 
 #if defined(EXERCISM_RUN_ALL_TESTS)
 BOOST_AUTO_TEST_CASE(test_2)
 {
-    const auto actual = gigasecond::advance(boost::gregorian::date(1977, 6, 14));
+    const auto actual = gigasecond::advance(time_from_string("1977-06-13 00:00:00"));
 
-    const boost::gregorian::date expected(2009, 2, 20);
+    const ptime expected(time_from_string("2009-02-19 01:46:40"));
     BOOST_REQUIRE_EQUAL(expected, actual);
 }
 
 BOOST_AUTO_TEST_CASE(test_3)
 {
-    const auto actual = gigasecond::advance(boost::gregorian::date(1959, 7, 20));
+    const auto actual = gigasecond::advance(time_from_string("1959-07-19 00:00:00"));
 
-    const boost::gregorian::date expected(1991, 3, 28);
+    const ptime expected(time_from_string("1991-03-27 01:46:40"));
+    BOOST_REQUIRE_EQUAL(expected, actual);
+}
+
+BOOST_AUTO_TEST_CASE(test_4)
+{
+    const auto actual = gigasecond::advance(time_from_string("2015-01-24 22:00:00"));
+
+    const ptime expected(time_from_string("2046-10-02 23:46:40"));
+    BOOST_REQUIRE_EQUAL(expected, actual);
+}
+
+BOOST_AUTO_TEST_CASE(test_5)
+{
+    const auto actual = gigasecond::advance(time_from_string("2015-01-24 23:59:59"));
+
+    const ptime expected(time_from_string("2046-10-03 01:46:39"));
     BOOST_REQUIRE_EQUAL(expected, actual);
 }
 #endif


### PR DESCRIPTION
Update gigasecond exercise to use times instead of dates.

Closes #34 
