### PR TITLE
nucleotide-count: Throw exception on constructor

### DIFF
--- a/exercises/nucleotide-count/example.cpp
+++ b/exercises/nucleotide-count/example.cpp
@@ -8,7 +8,11 @@ counter::counter(std::string const& sequence)
     : counts_({ {'A', 0}, {'C', 0}, {'G', 0}, {'T', 0} })
 {
     for (auto nucleotide : sequence) {
-        counts_[nucleotide]++;
+        auto it = counts_.find(nucleotide);
+        if (it == counts_.end()) {
+            throw std::invalid_argument("Unknown nucleotide");
+        }
+        ++(it->second);
     }
 }
 

--- a/exercises/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/nucleotide-count/nucleotide_count_test.cpp
@@ -62,6 +62,11 @@ BOOST_AUTO_TEST_CASE(validates_nucleotides)
     BOOST_REQUIRE_THROW(dna.count('X'), std::invalid_argument);
 }
 
+BOOST_AUTO_TEST_CASE(validates_nucleotides_on_construction)
+{
+    BOOST_REQUIRE_THROW(dna::counter("GGTTGGX"), std::invalid_argument);
+}
+
 BOOST_AUTO_TEST_CASE(counts_all_nucleotides)
 {
     const dna::counter dna("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");


### PR DESCRIPTION
Adds a test for invalid input in the constructor.

Closes #50.
