### PR TITLE
Let first 'make' fail for the right reason

### DIFF
--- a/exercises/etl/etl_test.cpp
+++ b/exercises/etl/etl_test.cpp
@@ -1,5 +1,6 @@
 #include "etl.h"
 #define BOOST_TEST_MAIN
+#include <map>
 #include <boost/test/unit_test.hpp>
 #include "require_equal_containers.h"
 


### PR DESCRIPTION
Currently, first make of the problem "etl" fails because the etl_tests.cpp file uses std::map without including <map>. Adding #include <map> fixes it. (Another way to "fix" is to include map inside of etl.h, but that feels like a "hack". The unit tests should include type declarations for types it's using itself! :) )