### PR TITLE
Remove require_equal_containers from CMake config.

### DIFF
--- a/exercises/anagram/CMakeLists.txt
+++ b/exercises/anagram/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/beer-song/CMakeLists.txt
+++ b/exercises/beer-song/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/binary/CMakeLists.txt
+++ b/exercises/binary/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/bob/CMakeLists.txt
+++ b/exercises/bob/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/clock/CMakeLists.txt
+++ b/exercises/clock/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/crypto-square/CMakeLists.txt
+++ b/exercises/crypto-square/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/difference-of-squares/CMakeLists.txt
+++ b/exercises/difference-of-squares/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/etl/CMakeLists.txt
+++ b/exercises/etl/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/food-chain/CMakeLists.txt
+++ b/exercises/food-chain/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/gigasecond/CMakeLists.txt
+++ b/exercises/gigasecond/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/grade-school/CMakeLists.txt
+++ b/exercises/grade-school/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/grains/CMakeLists.txt
+++ b/exercises/grains/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/hamming/CMakeLists.txt
+++ b/exercises/hamming/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/hello-world/CMakeLists.txt
+++ b/exercises/hello-world/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/hexadecimal/CMakeLists.txt
+++ b/exercises/hexadecimal/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/leap/CMakeLists.txt
+++ b/exercises/leap/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/meetup/CMakeLists.txt
+++ b/exercises/meetup/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/nth-prime/CMakeLists.txt
+++ b/exercises/nth-prime/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/nucleotide-count/CMakeLists.txt
+++ b/exercises/nucleotide-count/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/phone-number/CMakeLists.txt
+++ b/exercises/phone-number/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/prime-factors/CMakeLists.txt
+++ b/exercises/prime-factors/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/queen-attack/CMakeLists.txt
+++ b/exercises/queen-attack/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/raindrops/CMakeLists.txt
+++ b/exercises/raindrops/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/rna-transcription/CMakeLists.txt
+++ b/exercises/rna-transcription/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/robot-name/CMakeLists.txt
+++ b/exercises/robot-name/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/roman-numerals/CMakeLists.txt
+++ b/exercises/roman-numerals/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/say/CMakeLists.txt
+++ b/exercises/say/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/scrabble-score/CMakeLists.txt
+++ b/exercises/scrabble-score/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/series/CMakeLists.txt
+++ b/exercises/series/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/sieve/CMakeLists.txt
+++ b/exercises/sieve/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/space-age/CMakeLists.txt
+++ b/exercises/space-age/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/sum-of-multiples/CMakeLists.txt
+++ b/exercises/sum-of-multiples/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/triangle/CMakeLists.txt
+++ b/exercises/triangle/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/trinary/CMakeLists.txt
+++ b/exercises/trinary/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})

--- a/exercises/word-count/CMakeLists.txt
+++ b/exercises/word-count/CMakeLists.txt
@@ -33,15 +33,8 @@ else()
     set(exercise_cpp "")
 endif()
 
-# Include a test helper header if it exists
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/require_equal_containers.h)
-    set(test_helper require_equal_containers.h)
-else()
-    set(test_helper "")
-endif()
-
 # Build executable from sources and headers
-add_executable(${exercise} ${file}_test.cpp ${test_helper} ${exercise_cpp} ${file}.h)
+add_executable(${exercise} ${file}_test.cpp ${exercise_cpp} ${file}.h)
 
 # We need boost includes
 target_include_directories(${exercise} PRIVATE ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
I missed this config setting when taking out require_equal_containers.h in #118 

I will merge this as soon as I confirm that it passes on Travis-ci