### PR TITLE
Include map in two tests using map, but not including it

### DIFF
--- a/exercises/grade-school/grade_school_test.cpp
+++ b/exercises/grade-school/grade_school_test.cpp
@@ -1,5 +1,6 @@
 #include "grade_school.h"
 #define BOOST_TEST_MAIN
+#include <map>
 #include <boost/test/unit_test.hpp>
 #include "require_equal_containers.h"
 

--- a/exercises/nucleotide-count/nucleotide_count_test.cpp
+++ b/exercises/nucleotide-count/nucleotide_count_test.cpp
@@ -1,6 +1,7 @@
 #include "nucleotide_count.h"
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
+#include <map>
 #include <stdexcept>
 #include "require_equal_containers.h"
 


### PR DESCRIPTION
Added #include \<map\> to another two unit tests lacking it.